### PR TITLE
Typo in row 27

### DIFF
--- a/install-ip/concept_considerations_drive_assignment.adoc
+++ b/install-ip/concept_considerations_drive_assignment.adoc
@@ -24,7 +24,7 @@ NOTE: When upgrading from ONTAP 9.4 to 9.5, the system recognizes the existing d
 
 ADP is performed automatically during initial configuration of the platform.
 
-NOTE: Starting with ONTAP 9.5, `disk auto=assignment` must be enabled for automatic partitioning for ADP to occur.
+NOTE: Starting with ONTAP 9.5, `disk auto assignment` must be enabled for automatic partitioning for ADP to occur.
 
 == How shelf-by-shelf automatic assignment works
 


### PR DESCRIPTION
There was a typo in row 27 -  `disk auto=assignment` > modified.