### PR TITLE
Firewall Requirements for Cluster/Node Management LIF's

### DIFF
--- a/tiebreaker/reference_firewall_requirements_for_mcc_tiebreaker.adoc
+++ b/tiebreaker/reference_firewall_requirements_for_mcc_tiebreaker.adoc
@@ -40,36 +40,36 @@ a|
 a|
 Tiebreaker
 a|
-MetroCluster management LIFs
+MetroCluster Cluster Management LIFs
 a|
-Secure communications via HTTP (SSL)
+Secure communications to cluster via HTTP (SSL)
 a|
 22 / TCP
 
 a|
 Tiebreaker
 a|
-MetroCluster management LIFs
+MetroCluster Cluster Management LIFs
 a|
-Secure communications via SSH
+Secure communications to cluster via SSH
 a|
 443 / TCP
 
 a|
 Tiebreaker
 a|
-MetroCluster management LIFs
+MetroCluster Node Management LIFs
 a|
-Secure communications via HTTP (SSL)
+Secure communications to node via HTTP (SSL)
 a|
 22 / TCP
 
 a|
 Tiebreaker
 a|
-MetroCluster management LIFs
+MetroCluster Node Management LIFs
 a|
-Secure communications via SSH
+Secure communications to node via SSH
 a|
 162 / UDP
 
@@ -85,7 +85,7 @@ ICMP (ping)
 a|
 Tiebreaker
 a|
-MetroCluster management LIFs
+MetroCluster Cluster Management LIFs
 a|
 Check if cluster IP is reachable
 a|
@@ -94,7 +94,7 @@ ICMP (ping)
 a|
 Tiebreaker
 a|
-MetroCluster management LIFs
+MetroCluster Node Management LIFs
 a|
 Check if node IP is reachable
 |===


### PR DESCRIPTION
Updated Page [Firewall requirements for MetroCluster Tiebreaker](https://docs.netapp.com/us-en/ontap-metrocluster/tiebreaker/reference_firewall_requirements_for_mcc_tiebreaker.html) to distinguish (better) between the firewall requirements for Cluster Management LIF's and Node Management LIFs.

This should resolve NetAppDocs/ontap-metrocluster#117.